### PR TITLE
Update User/Trip model attributes and references

### DIFF
--- a/src/app/components/driver-info/driver-info.component.ts
+++ b/src/app/components/driver-info/driver-info.component.ts
@@ -68,7 +68,7 @@ export class DriverInfoComponent implements OnInit {
     } else {
       this.carService.getAllCars().subscribe(
         data => {
-          this.allAvailableCars = data.filter(car => car.user.isAcceptingRides && car.user.active);
+          this.allAvailableCars = data.filter(car => car.user.acceptingRides && car.user.active);
           this.orderByLocation();
         }
       )

--- a/src/app/components/login/login.component.spec.ts
+++ b/src/app/components/login/login.component.spec.ts
@@ -49,16 +49,16 @@ describe('LoginComponent', () => {
       email: 'john.smith@gmail.com',
       phoneNumber: '9171234567',
       active: true,
-      isDriver: true,
-      isAcceptingRides: true,
-      hAddress:{
+      driver: true,
+      acceptingRides: true,
+      homeAddress:{
         street:"123",
         apt:"",
         city:"Washington",
         state:"VI",
         zip:"12450",
       },
-      wAddress:{
+      workAddress:{
         street:"123",
         apt:"",
         city:"Washington",
@@ -87,16 +87,16 @@ describe('LoginComponent', () => {
       email: 'john.smith@gmail.com',
       phoneNumber: '9171234567',
       active: true,
-      isDriver: true,
-      isAcceptingRides: true,
-      hAddress:{
+      driver: true,
+      acceptingRides: true,
+      homeAddress:{
         street:"123",
         apt:"",
         city:"Washington",
         state:"VI",
         zip:"12450",
       },
-      wAddress:{
+      workAddress:{
         street:"123",
         apt:"",
         city:"Washington",

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -94,7 +94,7 @@ export class LoginComponent implements OnInit {
 					user.firstName.toLowerCase().startsWith(this.chosenUserFullName.toLowerCase()) ||
 					user.lastName.toLowerCase().startsWith(this.chosenUserFullName.toLowerCase()) ||
 					`${user.firstName} ${user.lastName}`.toLowerCase().startsWith(this.chosenUserFullName.toLowerCase()) ||
-					`${user.firstName} ${user.lastName}: ${user.isDriver ? 'Driver' : 'Rider'}`.toLowerCase().startsWith(this.chosenUserFullName.toLowerCase())
+					`${user.firstName} ${user.lastName}: ${user.driver ? 'Driver' : 'Rider'}`.toLowerCase().startsWith(this.chosenUserFullName.toLowerCase())
 				);
 			});
 			this.totalPage = Math.ceil(this.users.length / 5);

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -29,7 +29,7 @@ export class LoginComponent implements OnInit {
 
 	users: User[] = [];
 	allUsers: User[] = [];
-	
+
 
 	chosenUser: User;
 	chosenUserFullName: string = '';
@@ -150,11 +150,11 @@ export class LoginComponent implements OnInit {
 
 	/**
 	 * Opens the given modal template.
-	 * @param template 
+	 * @param template
 	 */
 	openModal(template :TemplateRef<any>){
 		this.modalRef = this.modalService.show(template);
-		
+
 	}
 
 	/**
@@ -165,7 +165,7 @@ export class LoginComponent implements OnInit {
 	login() {
 		this.pwdError ='';
 		this.usernameError= '';
-		
+
         this.http.get(`${environment.loginUri}?userName=${this.userName}&passWord=${this.passWord}`)
 			.subscribe(
                   (response) => {
@@ -178,7 +178,7 @@ export class LoginComponent implements OnInit {
 					  if((response["name"] != undefined) && (response["userid"] != undefined)){
 						sessionStorage.setItem("name", response["name"]);
 						sessionStorage.setItem("userid", response["userid"]);
-						
+
 						//call landing page
 						location.replace('landingPage');
 					  }
@@ -187,7 +187,7 @@ export class LoginComponent implements OnInit {
 					  }
                  }
         );
-		
+
 	}
 
 

--- a/src/app/components/preference/preference.component.html
+++ b/src/app/components/preference/preference.component.html
@@ -5,9 +5,9 @@
         Active: <button type="button" [ngClass]="user.active? truthy : falsy" (click)="toggleActive()">{{user.active? "On" : "Off"}}</button>
     </div><br>
     <div>
-        Driver: <button type="button" [ngClass]="user.isDriver? truthy : falsy" disabled>{{user.isDriver? "Yes" : "No"}}</button>
+        Driver: <button type="button" [ngClass]="user.driver? truthy : falsy" disabled>{{user.driver? "Yes" : "No"}}</button>
     </div><br>
     <div>
-        Accept Riders: <button type="button" [ngClass]="user.isAcceptingRides? truthy : falsy" (click)="toggleAcceptRider()" [disabled]="!(user.isDriver && user.active)">{{user.isAcceptingRides? "On" : "Off"}}</button>
+        Accept Riders: <button type="button" [ngClass]="user.acceptingRides? truthy : falsy" (click)="toggleAcceptRider()" [disabled]="!(user.driver && user.active)">{{user.acceptingRides? "On" : "Off"}}</button>
     </div>
 </div>

--- a/src/app/components/preference/preference.component.ts
+++ b/src/app/components/preference/preference.component.ts
@@ -70,7 +70,7 @@ export class PreferenceComponent implements OnInit {
       let text = prompt("Your Account Will Be Banned. Type 'Confirm' To Continued");
       if (text === 'Confirm') {
         this.user.active = !this.user.active;
-        this.user.isAcceptingRides = false;
+        this.user.acceptingRides = false;
         this.userService.updatePreference('active', this.user.active, this.user.userId);
       }
     } else {
@@ -85,7 +85,7 @@ export class PreferenceComponent implements OnInit {
    */
 
   toggleAcceptRider() {
-    this.user.isAcceptingRides = !this.user.isAcceptingRides;
-    this.userService.updatePreference('acceptingRides', this.user.isAcceptingRides, this.user.userId);
+    this.user.acceptingRides = !this.user.acceptingRides;
+    this.userService.updatePreference('acceptingRides', this.user.acceptingRides, this.user.userId);
   }
 }

--- a/src/app/components/profile-location/profile-location.component.ts
+++ b/src/app/components/profile-location/profile-location.component.ts
@@ -36,21 +36,21 @@ export class ProfileLocationComponent implements OnInit {
   ngOnInit() {
    this.userService.getUserById2(sessionStorage.getItem("userid")).subscribe((response: User)=>{
       this.currentUser = response;
-      this.zipcode = response.hAddress.zip;
-      this.city = response.hAddress.city;
-      this.address = response.hAddress.apt;
-      this.address2 = response.hAddress.street;
-      this.hState = response.hAddress.state;
+      this.zipcode = response.homeAddress.zip;
+      this.city = response.homeAddress.city;
+      this.address = response.homeAddress.apt;
+      this.address2 = response.homeAddress.street;
+      this.hState = response.homeAddress.state;
 
     });
   }
 
   addressChange = new FormGroup({
-    address1: new FormControl(`${this.currentUser.hAddress.apt}`, Validators.pattern('[a-z A-Z0-9]*')),
-    address2: new FormControl(`${this.currentUser.hAddress.street}`, [Validators.required, Validators.pattern('[0-9]{1,6}[a-z A-Z0-9]*')]),
-    city: new FormControl(`${this.currentUser.hAddress.city}`, [Validators.required, Validators.pattern('[a-z A-Z]*')]),
-    state: new FormControl(`${this.currentUser.hAddress.state}`, Validators.required),
-    zip: new FormControl(`${this.currentUser.hAddress.zip}`, [Validators.required, Validators.pattern('[0-9]{5}')]),
+    address1: new FormControl(`${this.currentUser.homeAddress.apt}`, Validators.pattern('[a-z A-Z0-9]*')),
+    address2: new FormControl(`${this.currentUser.homeAddress.street}`, [Validators.required, Validators.pattern('[0-9]{1,6}[a-z A-Z0-9]*')]),
+    city: new FormControl(`${this.currentUser.homeAddress.city}`, [Validators.required, Validators.pattern('[a-z A-Z]*')]),
+    state: new FormControl(`${this.currentUser.homeAddress.state}`, Validators.required),
+    zip: new FormControl(`${this.currentUser.homeAddress.zip}`, [Validators.required, Validators.pattern('[0-9]{5}')]),
   })
 
   async updatesContactInfo(){
@@ -66,7 +66,7 @@ export class ProfileLocationComponent implements OnInit {
     if(this.transientAddress == null){
       return;
     }else {
-      this.currentUser.hAddress = this.transientAddress;
+      this.currentUser.homeAddress = this.transientAddress;
       console.log(this.currentUser);
       this.userService.updateUserInfo(this.currentUser);
     }

--- a/src/app/components/profile-membership/profile-membership.component.html
+++ b/src/app/components/profile-membership/profile-membership.component.html
@@ -13,7 +13,7 @@
                 <div class="form-group row">
                      <div class="col-sm-4 t">
                     <h6>Status:</h6>
-                    <select class="form-control mySelect" name="rider" id="rider" [(ngModel)]=isDriver value="{{profileObject.isDriver}}">
+                    <select class="form-control mySelect" name="rider" id="rider" [(ngModel)]=driver value="{{profileObject.driver}}">
                         <option value="true">Driver</option>
                         <option value="false">Rider</option>
                     </select>

--- a/src/app/components/profile-membership/profile-membership.component.ts
+++ b/src/app/components/profile-membership/profile-membership.component.ts
@@ -12,7 +12,7 @@ import { User } from 'src/app/models/user';
 export class ProfileMembershipComponent implements OnInit {
   profileObject = new User();
   currentUser: any = '';
-  isDriver: boolean;
+  driver: boolean;
   active: boolean;
   success: string;
   constructor(private userService: UserService) { }
@@ -30,7 +30,7 @@ export class ProfileMembershipComponent implements OnInit {
    * this component, and persists those changes to the database.
    */
   updatesMembershipInfo(){
-    this.profileObject.isDriver = this.isDriver;
+    this.profileObject.driver = this.driver;
     this.profileObject.active = this.active;
     this.userService.updateUserInfo(this.profileObject);
     this.success = "Updated Successfully!";

--- a/src/app/components/sign-up-modal/sign-up-modal.component.ts
+++ b/src/app/components/sign-up-modal/sign-up-modal.component.ts
@@ -117,7 +117,7 @@ export class SignupModalComponent implements OnInit {
         return;
       } else {
         this.modalRef.hide();
-        this.user.hAddress = finalAddress;
+        this.user.homeAddress = finalAddress;
         this.userService.addUser(this.user);
         return;
       }

--- a/src/app/components/sign-up-modal/sign-up-modal.component.ts
+++ b/src/app/components/sign-up-modal/sign-up-modal.component.ts
@@ -92,16 +92,16 @@ export class SignupModalComponent implements OnInit {
       //Switch Statement to set the user to either a rider, driver, or both
       switch(this.signup.controls.driver.value){
         case "driver":{
-          this.user.isDriver = true;
+          this.user.driver = true;
           break;
         }
         case "rider":{
-          this.user.isAcceptingRides = true;
+          this.user.acceptingRides = true;
           break;
         }
         case "both":{
-          this.user.isAcceptingRides = true;
-          this.user.isDriver = true;
+          this.user.acceptingRides = true;
+          this.user.driver = true;
           break;
         }
       }

--- a/src/app/models/trip-status.ts
+++ b/src/app/models/trip-status.ts
@@ -1,0 +1,5 @@
+const enum TripStatus {
+    PAST = 0,
+    CURRENT = 1,
+    FUTURE = 2
+}

--- a/src/app/models/trip.ts
+++ b/src/app/models/trip.ts
@@ -1,7 +1,7 @@
 import { User } from './user';
 import {Address} from './address';
 
-export class Trip 
+export class Trip
 {
     tripId: number;
     name: string;
@@ -10,5 +10,6 @@ export class Trip
     availableSeats: number;
     departure: Address;
     destination: Address;
-    tripDate: string;
+    tripDate: Date;
+    tripStatus: TripStatus;
 }

--- a/src/app/models/tripStatus.ts
+++ b/src/app/models/tripStatus.ts
@@ -1,5 +1,0 @@
-enum TripStatus {
-    PAST,
-    CURRENT,
-    FUTURE
-}

--- a/src/app/models/tripStatus.ts
+++ b/src/app/models/tripStatus.ts
@@ -1,0 +1,5 @@
+enum TripStatus {
+    PAST,
+    CURRENT,
+    FUTURE
+}

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -9,7 +9,7 @@ export class User {
      * Set User model
      */
     userId: number;
-    
+
     /**
      * Set username as a string
      */
@@ -17,49 +17,49 @@ export class User {
     /**
      * Attached a batch object
      */
-    
-     batch: Batch = new Batch();
-    
+
+    batch: Batch = new Batch();
+
     /**
      * Set first name as a string
      */
-     firstName: string;
-    
+    firstName: string;
+
      /**
      * Set last name as a string
      */
-     lastName: string;
-    
+    lastName: string;
+
      /**
      * Set email as a string
      */
     email: string;
-    
+
     /**
      * Set phone number as a string
      */
     phoneNumber: string;
-    
+
     /**
      * Set active as a boolean
      */
     active: boolean;
-    
+
     /**
      * Set driver as a boolean
      */
-    isDriver: boolean;
-    
+    driver: boolean;
+
     /**
      * Set accepting ride as a boolean
      */
-    isAcceptingRides: boolean;
-    
+    acceptingRides: boolean;
+
     /**
      * Home Address
      */
     hAddress: Address;
-    
+
     /**
      * Work Address
      */

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -14,10 +14,10 @@ export class User {
      * Set username as a string
      */
     userName: string;
-    /**
-     * Attached a batch object
-     */
 
+    /**
+     * Batch a User belongs to
+     */
     batch: Batch = new Batch();
 
     /**
@@ -58,10 +58,10 @@ export class User {
     /**
      * Home Address
      */
-    hAddress: Address;
+    homeAddress: Address;
 
     /**
      * Work Address
      */
-    wAddress: Address;
+    workAddress: Address;
 }

--- a/src/app/services/user-service/user.service.ts
+++ b/src/app/services/user-service/user.service.ts
@@ -84,8 +84,8 @@ export class UserService {
 	createDriver(user: User, role) {
 
 		user.active = true;
-		user.isDriver = false;
-		user.isAcceptingRides = false;
+		user.driver = false;
+		user.acceptingRides = false;
 		console.log(user);
 
 		this.http.post(this.url, user, {observe: 'response'}).subscribe(
@@ -134,8 +134,8 @@ export class UserService {
 		this.getUserById(userId)
 			.then((response) => {
 				this.user = response;
-				this.user.isDriver = isDriver;
-				this.user.isAcceptingRides = (this.user.active && isDriver);
+				this.user.driver = isDriver;
+				this.user.acceptingRides = (this.user.active && isDriver);
 
 				this.http.put(this.url+userId, this.user).subscribe(
 					(response) => {
@@ -164,7 +164,7 @@ export class UserService {
 				this.user = response;
 				this.user[property] = bool;
 				if (property === 'active' && bool === false) {
-					this.user.isAcceptingRides = false;
+					this.user.acceptingRides = false;
 				}
 
 				this.http.put(this.url+userId, this.user).subscribe(

--- a/src/app/services/validation-service/validation.service.ts
+++ b/src/app/services/validation-service/validation.service.ts
@@ -86,6 +86,10 @@ export class ValidationService {
 	}
 
 	validateAddress(address: Address) {
+		if(address.apt == null) {
+            address.apt = '';
+		}
+		
 		let url = "https://secure.shippingapis.com/ShippingAPI.dll?API=Verify&XML=";
     	//probably need to hide this API userID--->____________
 		let xml = 


### PR DESCRIPTION
User model fields prepended with `is` in the back-end were being received without `is`. Additionally, `hAddress` was being received with a lower-case `a`, as was `wAddress`. We've dropped the `is` from back-end model fields, and went with `homeAddress` and `workAddress` to work around this issue and improve code readability. This PR is done in tandem with the back-end change, and all old front-end model attribute references app-wide have been updated to match this update.

Lastly, the Trip model from the back-end now has a `tripStatus` field, so this PR updates the existing  front-end model as well.